### PR TITLE
feat: add hailing system for GM and player communication

### DIFF
--- a/sta/database/db.py
+++ b/sta/database/db.py
@@ -70,6 +70,11 @@ def run_migrations():
             conn.commit()
             print("Migration: Added description column to encounters table")
 
+        if 'hailing_state_json' not in encounter_columns:
+            conn.execute(text("ALTER TABLE encounters ADD COLUMN hailing_state_json TEXT"))
+            conn.commit()
+            print("Migration: Added hailing_state_json column to encounters table")
+
         # GM password migration
         result = conn.execute(text("PRAGMA table_info(campaigns)"))
         campaign_columns = [row[1] for row in result.fetchall()]

--- a/sta/database/schema.py
+++ b/sta/database/schema.py
@@ -292,6 +292,10 @@ class EncounterRecord(Base):
     # Viewscreen audio settings (GM-controlled)
     viewscreen_audio_enabled: Mapped[bool] = mapped_column(default=True)
 
+    # Hailing state (JSON or null)
+    # Structure: {"active": bool, "initiator": "player|gm", "target": str, "from_ship": str, "to_ship": str, "channel_open": bool, "timestamp": str}
+    hailing_state_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True, default=None)
+
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now, onupdate=datetime.now)
 

--- a/sta/web/templates/combat_gm.html
+++ b/sta/web/templates/combat_gm.html
@@ -894,6 +894,11 @@
                                 <button class="resource-btn" onclick="updateThreat(1)">+</button>
                             </div>
                         </div>
+                        <div class="resource-box" style="background: linear-gradient(135deg, rgba(255, 153, 102, 0.15), rgba(255, 204, 102, 0.15)); border-color: var(--lcars-butterscotch);">
+                            <span class="resource-label" style="color: var(--lcars-butterscotch);">Communications</span>
+                            <button class="btn btn-small" onclick="hailPlayerShip()" id="hail-btn" style="margin-top: 8px; background: var(--lcars-butterscotch); color: var(--lcars-text-dark);">Hail Player Ship</button>
+                            <button class="btn btn-small" onclick="closeChannel()" id="close-channel-btn" style="display: none; margin-top: 8px; background: var(--lcars-tomato); color: var(--lcars-text-dark);">Close Channel</button>
+                        </div>
                     </div>
 
                     <!-- Ships Overview - All ships with shield status and action buttons -->
@@ -1612,6 +1617,51 @@
                 // Revert on error
                 viewscreenAudioEnabled = !viewscreenAudioEnabled;
                 console.error('Failed to toggle viewscreen audio:', err);
+            }
+        }
+
+        // ===== HAILING FUNCTIONS =====
+
+        async function hailPlayerShip() {
+            try {
+                // Get the first enemy ship's name for "from_ship"
+                const enemyShips = document.querySelectorAll('.ship-card-enemy');
+                const fromShip = enemyShips.length > 0 ? enemyShips[0].querySelector('.ship-name')?.textContent.trim() : 'Unknown Vessel';
+
+                const response = await fetch(`/api/encounter/${encounterId}/initiate-hail`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        initiator: 'gm',
+                        target_ship: '{{ player_ship.name }}',
+                        from_ship: fromShip
+                    })
+                });
+
+                if (response.ok) {
+                    fetchStatus(); // Refresh to update UI
+                } else {
+                    console.error('Failed to initiate hail');
+                }
+            } catch (err) {
+                console.error('Error initiating hail:', err);
+            }
+        }
+
+        async function closeChannel() {
+            try {
+                const response = await fetch(`/api/encounter/${encounterId}/close-channel`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'}
+                });
+
+                if (response.ok) {
+                    fetchStatus(); // Refresh to update UI
+                } else {
+                    console.error('Failed to close channel');
+                }
+            } catch (err) {
+                console.error('Error closing channel:', err);
             }
         }
 
@@ -2432,8 +2482,30 @@
                         hasReservePower = data.has_reserve_power;
                         updateReservePowerDisplay();
                     }
+
+                    // Update hailing button state
+                    updateHailingButtons(data.hailing_state);
                 }
             } catch (e) {}
+        }
+
+        function updateHailingButtons(hailingState) {
+            const hailBtn = document.getElementById('hail-btn');
+            const closeBtn = document.getElementById('close-channel-btn');
+
+            if (!hailingState) {
+                // No active hail - show hail button
+                hailBtn.style.display = 'block';
+                closeBtn.style.display = 'none';
+            } else if (hailingState.channel_open) {
+                // Channel is open - show close button
+                hailBtn.style.display = 'none';
+                closeBtn.style.display = 'block';
+            } else {
+                // Hail is active (waiting for response) - hide both
+                hailBtn.style.display = 'none';
+                closeBtn.style.display = 'none';
+            }
         }
 
         // Initialize

--- a/sta/web/templates/combat_player_new.html
+++ b/sta/web/templates/combat_player_new.html
@@ -1023,6 +1023,24 @@
                         {% endif %}
                     </div>
 
+                    <!-- Hailing Notification Panel -->
+                    <div id="hailing-notification" style="display: none; padding: 15px; background: linear-gradient(135deg, rgba(255, 153, 102, 0.2), rgba(255, 204, 102, 0.2)); border: 2px solid var(--lcars-butterscotch); border-radius: 8px; margin-bottom: 15px;">
+                        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px;">
+                            <div style="flex: 1;">
+                                <div id="hailing-status-text" style="color: var(--lcars-butterscotch); font-size: 1.2em; font-weight: bold; margin-bottom: 5px;">INCOMING HAIL</div>
+                                <div id="hailing-from-text" style="color: var(--lcars-almond); font-size: 0.95em;"></div>
+                            </div>
+                            <div id="hailing-actions" style="display: flex; gap: 10px;">
+                                <button onclick="respondToHail(true)" style="padding: 10px 20px; background: var(--lcars-success); border: none; border-radius: 20px; color: var(--lcars-text-dark); font-weight: bold; cursor: pointer;">ACCEPT</button>
+                                <button onclick="respondToHail(false)" style="padding: 10px 20px; background: var(--lcars-tomato); border: none; border-radius: 20px; color: var(--lcars-text-dark); font-weight: bold; cursor: pointer;">REJECT</button>
+                            </div>
+                            <div id="hailing-channel-status" style="display: none;">
+                                <div style="color: var(--lcars-success); font-size: 1em; font-weight: bold; margin-bottom: 5px;">✓ CHANNEL OPEN</div>
+                                <button onclick="closeChannel()" style="padding: 8px 16px; background: var(--lcars-tomato); border: none; border-radius: 15px; color: var(--lcars-text-dark); font-weight: bold; cursor: pointer; font-size: 0.9em;">CLOSE CHANNEL</button>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Station-Specific Info Panel -->
                     <div class="station-info-panel" style="padding: 12px; background: #1a1a1a; border-radius: 8px; margin-bottom: 15px;">
                         {% if position.value == 'tactical' %}
@@ -4676,6 +4694,9 @@
                     } else if (!data.pending_attack && pendingAttackData) {
                         hidePendingAttackPanel();
                     }
+
+                    // Handle hailing state
+                    updateHailingNotification(data.hailing_state);
                 }
             } catch (e) {
                 console.error('Failed to fetch turn status:', e);
@@ -4932,6 +4953,78 @@
                 }
             } catch (error) {
                 console.error('Error refreshing map:', error);
+            }
+        }
+
+        // ===== HAILING FUNCTIONS =====
+
+        function updateHailingNotification(hailingState) {
+            const notification = document.getElementById('hailing-notification');
+            const statusText = document.getElementById('hailing-status-text');
+            const fromText = document.getElementById('hailing-from-text');
+            const actions = document.getElementById('hailing-actions');
+            const channelStatus = document.getElementById('hailing-channel-status');
+
+            if (!hailingState) {
+                notification.style.display = 'none';
+                return;
+            }
+
+            notification.style.display = 'block';
+
+            if (hailingState.active && hailingState.initiator === 'gm') {
+                // Incoming hail from GM
+                statusText.textContent = 'INCOMING HAIL';
+                fromText.textContent = `From: ${hailingState.from_ship}`;
+                actions.style.display = 'flex';
+                channelStatus.style.display = 'none';
+            } else if (hailingState.channel_open) {
+                // Channel is open
+                statusText.textContent = '✓ CHANNEL OPEN';
+                fromText.textContent = `Communication established with ${hailingState.to_ship}`;
+                actions.style.display = 'none';
+                channelStatus.style.display = 'block';
+            } else {
+                // Hail initiated by player, waiting for response
+                statusText.textContent = 'HAILING...';
+                fromText.textContent = `Hailing ${hailingState.to_ship}`;
+                actions.style.display = 'none';
+                channelStatus.style.display = 'none';
+            }
+        }
+
+        async function respondToHail(accepted) {
+            try {
+                const response = await fetch(`/api/encounter/${encounterId}/respond-hail`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ accepted })
+                });
+
+                if (response.ok) {
+                    fetchTurnStatus(); // Refresh to update UI
+                } else {
+                    console.error('Failed to respond to hail');
+                }
+            } catch (e) {
+                console.error('Error responding to hail:', e);
+            }
+        }
+
+        async function closeChannel() {
+            try {
+                const response = await fetch(`/api/encounter/${encounterId}/close-channel`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+
+                if (response.ok) {
+                    fetchTurnStatus(); // Refresh to update UI
+                } else {
+                    console.error('Failed to close channel');
+                }
+            } catch (e) {
+                console.error('Error closing channel:', e);
             }
         }
     </script>

--- a/sta/web/templates/combat_viewscreen.html
+++ b/sta/web/templates/combat_viewscreen.html
@@ -551,6 +551,83 @@
         .lcars-data-fill.animated .lcars-data-row:nth-child(3n) {
             animation-delay: 1s;
         }
+
+        /* Hailing Overlay Styles */
+        .hailing-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.95);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 10000;
+            animation: fadeIn 0.3s ease-in;
+        }
+
+        .hailing-overlay.active {
+            display: flex;
+        }
+
+        .hailing-content {
+            text-align: center;
+            padding: 60px;
+            background: linear-gradient(135deg, rgba(153, 102, 255, 0.1), rgba(255, 153, 153, 0.1));
+            border: 5px solid var(--lcars-butterscotch);
+            border-radius: 30px;
+            max-width: 800px;
+            animation: slideIn 0.4s ease-out;
+        }
+
+        .hailing-header {
+            color: var(--lcars-butterscotch);
+            font-size: 3rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 4px;
+            margin-bottom: 20px;
+            animation: pulse 2s infinite;
+        }
+
+        .hailing-from {
+            color: var(--lcars-almond);
+            font-size: 2rem;
+            margin-bottom: 10px;
+        }
+
+        .hailing-message {
+            color: var(--lcars-ice);
+            font-size: 1.4rem;
+            margin-top: 30px;
+            line-height: 1.6;
+        }
+
+        .hailing-channel-open {
+            color: var(--lcars-success);
+            font-size: 2.5rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 3px;
+            margin-bottom: 20px;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @keyframes slideIn {
+            from {
+                transform: translateY(-50px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
     </style>
 </head>
 <body>
@@ -765,6 +842,15 @@
             <div class="viewscreen-bottom-left"></div>
             <div class="viewscreen-bottom-main"></div>
             <div class="viewscreen-bottom-right"></div>
+        </div>
+    </div>
+
+    <!-- Hailing Overlay -->
+    <div id="hailing-overlay" class="hailing-overlay">
+        <div class="hailing-content">
+            <div id="hailing-header" class="hailing-header">INCOMING HAIL</div>
+            <div id="hailing-from" class="hailing-from"></div>
+            <div id="hailing-message" class="hailing-message">Hailing frequencies open</div>
         </div>
     </div>
 
@@ -1163,6 +1249,59 @@
             HexMap.hexSize = originalHexSize;
         }
 
+        // Hailing state tracking
+        let currentHailingState = null;
+        let hailingSoundPlayed = false;
+
+        function handleHailingState(hailingState) {
+            const overlay = document.getElementById('hailing-overlay');
+            const header = document.getElementById('hailing-header');
+            const from = document.getElementById('hailing-from');
+            const message = document.getElementById('hailing-message');
+
+            // If no hailing state, hide overlay
+            if (!hailingState) {
+                overlay.classList.remove('active');
+                currentHailingState = null;
+                hailingSoundPlayed = false;
+                return;
+            }
+
+            // Check if this is a new hail
+            const isNewHail = !currentHailingState ||
+                             JSON.stringify(currentHailingState) !== JSON.stringify(hailingState);
+
+            if (isNewHail) {
+                currentHailingState = hailingState;
+                hailingSoundPlayed = false;
+            }
+
+            // Handle incoming hail (active = true)
+            if (hailingState.active) {
+                header.textContent = 'INCOMING HAIL';
+                from.textContent = `From: ${hailingState.from_ship}`;
+                message.textContent = 'Hailing frequencies open';
+                overlay.classList.add('active');
+
+                // Play hailing sound once per new hail
+                if (!hailingSoundPlayed) {
+                    SoundManager.playSound('/static/audio/sounds/ui/tng_hail.mp3');
+                    hailingSoundPlayed = true;
+                }
+            }
+            // Handle open channel (channel_open = true, active = false)
+            else if (hailingState.channel_open) {
+                header.textContent = 'CHANNEL OPEN';
+                header.className = 'hailing-channel-open';
+                from.textContent = `${hailingState.from_ship}`;
+                message.textContent = 'Communication established';
+                overlay.classList.add('active');
+            }
+            else {
+                overlay.classList.remove('active');
+            }
+        }
+
         // Fetch and update status
         async function fetchStatus() {
             try {
@@ -1248,6 +1387,9 @@
                 if (data.viewscreen_audio_enabled !== undefined) {
                     SoundManager.setAmbientEnabled(data.viewscreen_audio_enabled);
                 }
+
+                // Handle hailing state
+                handleHailingState(data.hailing_state);
 
             } catch (error) {
                 console.error('Failed to fetch status:', error);


### PR DESCRIPTION
Implements a complete hailing system allowing GMs to initiate hails to the
player ship and players to respond. Features include:

- **Database**: Added hailing_state_json field to EncounterRecord for tracking
  hailing state (active, initiator, ships, channel status)
- **Migration**: Auto-migration for new hailing_state_json column
- **API Endpoints**:
  - POST /api/encounter/<id>/initiate-hail - Start a hail
  - POST /api/encounter/<id>/respond-hail - Accept/reject hail
  - POST /api/encounter/<id>/close-channel - Close open channel
  - GET /api/encounter/<id>/status - Now includes hailing_state

- **Viewscreen UI**:
  - Full-screen LCARS-styled overlay for incoming hails
  - Shows "INCOMING HAIL" with ship name
  - Displays "CHANNEL OPEN" when communication is established
  - Plays hailing sound effect (requires tng_hail.mp3)
  - Auto-updates via existing status polling (2s interval)

- **Player UI**:
  - Notification banner showing incoming hails
  - Accept/Reject buttons for GM-initiated hails
  - Visual indication of open channels
  - Close Channel button when comms are active

- **GM UI**:
  - "Hail Player Ship" button in Communications panel
  - "Close Channel" button when channel is open
  - Button states update automatically based on hailing status

All views use the existing polling infrastructure (no WebSockets required).
The system is purely visual for in-person roleplay scenarios.

Note: Users need to download and place a Star Trek hailing sound at:
sta/web/static/audio/sounds/ui/tng_hail.mp3